### PR TITLE
Added Updated Camera Tracking and SwerveDrivePoseEstimator

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -1,5 +1,8 @@
 package frc.robot;
-import edu.wpi.first.wpilibj.PneumaticsModuleType;
+
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
 
 public final class Constants {
 
@@ -87,4 +90,8 @@ public final class Constants {
     public static final int MAX_GREEN_CUBE = 92;
     public static final int MIN_BLUE_CUBE = 151;
     public static final int MAX_BLUE_CUBE = 211;
+
+    // Distance From Center of Robot To Cameras
+    public static final Transform3d FRONT_CAM_TO_CENTER = new Transform3d(new Translation3d(-0.0762, 0.1524, 0.9398), new Rotation3d(0,0,0));
+    public static final Transform3d BACK_CAM_TO_CENTER = new Transform3d(new Translation3d(0.0762, 0.1524, 0.9398), new Rotation3d(0,0,0));
 }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -219,19 +219,20 @@ public class DriveSubsystem extends SubsystemBase {
             }
         );
 
-        EstimatedRobotPose resultToUse = null;
-        double lowestAmbiguity = 1;
 
         if(frontCameraRobotFieldPosition != null) {
             frontCameraRobotFieldPosition.setLastPose(getPose());
             Optional<EstimatedRobotPose> frontCameraPose = frontCameraRobotFieldPosition.getEstimatedGlobalPose();
             if(frontCameraPose.isPresent()) {
+                double lowestAmbiguity = 1;
                 for(PhotonTrackedTarget target : frontCameraPose.get().targetsUsed) {
                     if(target.getPoseAmbiguity() < lowestAmbiguity) {
                         System.out.println("yes");
                         lowestAmbiguity = target.getPoseAmbiguity();
-                        resultToUse = frontCameraPose.get();
                     }
+                }
+                if (lowestAmbiguity < 0.3) {
+                    odometry.addVisionMeasurement(frontCameraPose.get().estimatedPose.toPose2d(), Timer.getFPGATimestamp());
                 }
             }
         }
@@ -240,18 +241,16 @@ public class DriveSubsystem extends SubsystemBase {
             frontCameraRobotFieldPosition.setLastPose(getPose());
             Optional<EstimatedRobotPose> backCameraPose = backCameraRobotFieldPosition.getEstimatedGlobalPose();
             if(backCameraPose.isPresent()) {
+                double lowestAmbiguity = 1;
                 for(PhotonTrackedTarget target : backCameraPose.get().targetsUsed) {
                     if(target.getPoseAmbiguity() < lowestAmbiguity) {
                         lowestAmbiguity = target.getPoseAmbiguity();
-                        resultToUse = backCameraPose.get();
                     }
                 }
+                if (lowestAmbiguity < 0.3) {
+                    odometry.addVisionMeasurement(backCameraPose.get().estimatedPose.toPose2d(), Timer.getFPGATimestamp());
+                }
             }
-        }
-
-        //TODO Factor in the position if ambiguity is above 0.05
-        if(resultToUse != null && lowestAmbiguity < 0.05) {
-            odometry.addVisionMeasurement(resultToUse.estimatedPose.toPose2d(), Timer.getFPGATimestamp());
         }
 
 

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,0 +1,41 @@
+{
+    "fileName": "photonlib.json",
+    "name": "photonlib",
+    "version": "v2023.4.2",
+    "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004 ",
+    "mavenUrls": [
+        "https://maven.photonvision.org/repository/internal",
+        "https://maven.photonvision.org/repository/snapshots"
+    ],
+    "jsonUrl": "https://maven.photonvision.org/repository/internal/org/photonvision/PhotonLib-json/1.0/PhotonLib-json-1.0.json",
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "PhotonLib-cpp",
+            "version": "v2023.4.2",
+            "libName": "Photon",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxathena",
+                "linuxx86-64",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "javaDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "PhotonLib-java",
+            "version": "v2023.4.2"
+        },
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "PhotonTargeting-java",
+            "version": "v2023.4.2"
+        }
+    ]
+}


### PR DESCRIPTION
# Added Camera Tracking and SwerveDrivePoseEstimator
## SwerveDrivePoseEstimator
Replaces SwerveDriveOdometry and lets you factor in multiple positions from odometry and Camera Tracking.
## April Tags
Factors in April Tag Positioning if the lowest target ambiguity is less than 0.3. Works with X/Y/Gyro.
## Extra Stuff
Merge [this pull request](https://github.com/FairportRobotics/potential-octo-eureka) before merging this since it has some needed methods.
<br/>
<img src="https://media.istockphoto.com/id/175440771/photo/handsome-young-man-gesturing-thumbs-up-isolated.webp?s=1024x1024&w=is&k=20&c=gcy1v4sqgDVDyqjogJ-qz1cssR8nBfjnlhPAia30bnY=" width="50%">
<table>
  <tr>
    <td><img src="https://picsum.photos/200?random=1" alt="Random Image"></td>
    <td><img src="https://picsum.photos/200?random=2" alt="Random Image"></td>
    <td><img src="https://picsum.photos/200?random=3" alt="Random Image"></td>
  </tr>
  <tr>
    <td><img src="https://picsum.photos/200?random=4" alt="Random Image"></td>
    <td><img src="https://picsum.photos/200?random=5" alt="Random Image"></td>
    <td><img src="https://picsum.photos/200?random=6" alt="Random Image"></td>
  </tr>
  <tr>
    <td><img src="https://picsum.photos/200?random=7" alt="Random Image"></td>
    <td><img src="https://picsum.photos/200?random=8" alt="Random Image"></td>
    <td><img src="https://picsum.photos/200?random=9" alt="Random Image"></td>
  </tr>
</table>
